### PR TITLE
Add opacity to text and background colors

### DIFF
--- a/packages/frontity-org-theme/src/index.ts
+++ b/packages/frontity-org-theme/src/index.ts
@@ -24,6 +24,19 @@ const frontityOrg: FrontityOrg = {
   },
   actions: {
     theme: {}
+  },
+  libraries: {
+    theme: {
+      colors: {
+        addAlpha: (hex, alpha) =>
+          `rgba(${hex
+            .match(/^#(.{2})(.{2})(.{2})$/)
+            .slice(1)
+            .map(value => Number(`0x${value}`))
+            .concat(alpha)
+            .join(", ")})`
+      }
+    }
   }
 };
 

--- a/packages/frontity-org-theme/src/index.ts
+++ b/packages/frontity-org-theme/src/index.ts
@@ -27,15 +27,6 @@ const frontityOrg: FrontityOrg = {
     theme: {}
   },
   libraries: {
-    theme: {
-      addAlpha: (hex, alpha) =>
-        `rgba(${hex
-          .match(/^#(.{2})(.{2})(.{2})$/)
-          .slice(1)
-          .map(value => Number(`0x${value}`))
-          .concat(alpha)
-          .join(", ")})`
-    },
     html2react: {
       processors: [backgroundColor, textColor]
     }

--- a/packages/frontity-org-theme/src/processors/background-color.tsx
+++ b/packages/frontity-org-theme/src/processors/background-color.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { css } from "frontity";
 import { Processor } from "@frontity/html2react/types";
 import FrontityOrg from "../../types";
+import { addAlpha } from "../utils";
 
 const colorClassRegex = /has-([\w-]+)-background-color/;
 const opacityClassRegex = /has-background-opacity-(\d+)/;
@@ -12,7 +13,7 @@ const backgroundColor: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
     node.type === "element" &&
     node.props.className &&
     node.props.className.split(" ").includes("has-background"),
-  processor: ({ node, state, libraries }) => {
+  processor: ({ node, state }) => {
     if (node.type === "element") {
       // Get the class with the color name.
       const colorClass = node.props.className
@@ -37,7 +38,7 @@ const backgroundColor: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
           const [, opacityValue] = opacityClass.match(opacityClassRegex);
 
           // Assign color value with the opacity.
-          color = libraries.theme.addAlpha(
+          color = addAlpha(
             state.theme.colors[colorName],
             Number(opacityValue) / 100
           );

--- a/packages/frontity-org-theme/src/processors/background-color.tsx
+++ b/packages/frontity-org-theme/src/processors/background-color.tsx
@@ -4,6 +4,7 @@ import { Processor } from "@frontity/html2react/types";
 import FrontityOrg from "../../types";
 
 const colorClassRegex = /has-([\w-]+)-background-color/;
+const opacityClassRegex = /has-background-opacity-(\d+)/;
 
 const backgroundColor: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
   name: "backgroundColor",
@@ -11,7 +12,7 @@ const backgroundColor: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
     node.type === "element" &&
     node.props.className &&
     node.props.className.split(" ").includes("has-background"),
-  processor: ({ node, state }) => {
+  processor: ({ node, state, libraries }) => {
     if (node.type === "element") {
       // Get the class with the color name.
       const colorClass = node.props.className
@@ -20,12 +21,35 @@ const backgroundColor: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
 
       // Get the color name from that class.
       if (colorClass) {
+        // Color code.
+        let color: string;
+
+        // Get the color name from that class.
         const [, colorName] = colorClass.match(colorClassRegex);
+
+        // Get the opacity class if exists.
+        const opacityClass = node.props.className
+          .split(" ")
+          .find(name => opacityClassRegex.test(name));
+
+        if (opacityClass) {
+          // Get the value from the opacity class.
+          const [, opacityValue] = opacityClass.match(opacityClassRegex);
+
+          // Assign color value with the opacity.
+          color = libraries.theme.addAlpha(
+            state.theme.colors[colorName],
+            Number(opacityValue) / 100
+          );
+        } else {
+          // Get the color code from state.
+          color = state.theme.colors[colorName];
+        }
 
         // Replace the `css` prop with a new one with `background-color`.
         node.props.css = css`
           ${node.props.css}
-          background-color: ${state.theme.colors[colorName]};
+          background-color: ${color};
         `;
       }
     }

--- a/packages/frontity-org-theme/src/processors/text-color.tsx
+++ b/packages/frontity-org-theme/src/processors/text-color.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { css } from "frontity";
 import { Processor } from "@frontity/html2react/types";
 import FrontityOrg from "../../types";
+import { addAlpha } from "../utils";
 
 const colorClassRegex = /has-([\w-]+)-color/;
 const opacityClassRegex = /has-text-opacity-(\d+)/;
@@ -12,7 +13,7 @@ const textColor: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
     node.type === "element" &&
     node.props.className &&
     node.props.className.split(" ").includes("has-text-color"),
-  processor: ({ node, state, libraries }) => {
+  processor: ({ node, state }) => {
     if (node.type === "element") {
       // Get the class with the color name.
       const colorClass = node.props.className
@@ -40,7 +41,7 @@ const textColor: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
           const [, opacityValue] = opacityClass.match(opacityClassRegex);
 
           // Assign color value with the opacity.
-          color = libraries.theme.addAlpha(
+          color = addAlpha(
             state.theme.colors[colorName],
             Number(opacityValue) / 100
           );

--- a/packages/frontity-org-theme/src/processors/text-color.tsx
+++ b/packages/frontity-org-theme/src/processors/text-color.tsx
@@ -4,6 +4,7 @@ import { Processor } from "@frontity/html2react/types";
 import FrontityOrg from "../../types";
 
 const colorClassRegex = /has-([\w-]+)-color/;
+const opacityClassRegex = /has-text-opacity-(\d+)/;
 
 const textColor: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
   name: "textColor",
@@ -11,7 +12,7 @@ const textColor: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
     node.type === "element" &&
     node.props.className &&
     node.props.className.split(" ").includes("has-text-color"),
-  processor: ({ node, state }) => {
+  processor: ({ node, state, libraries }) => {
     if (node.type === "element") {
       // Get the class with the color name.
       const colorClass = node.props.className
@@ -23,13 +24,35 @@ const textColor: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
         );
 
       if (colorClass) {
+        // Color code.
+        let color: string;
+
         // Get the color name from that class.
         const [, colorName] = colorClass.match(colorClassRegex);
+
+        // Get the opacity class if exists.
+        const opacityClass = node.props.className
+          .split(" ")
+          .find(name => opacityClassRegex.test(name));
+
+        if (opacityClass) {
+          // Get the value from the opacity class.
+          const [, opacityValue] = opacityClass.match(opacityClassRegex);
+
+          // Assign color value with the opacity.
+          color = libraries.theme.addAlpha(
+            state.theme.colors[colorName],
+            Number(opacityValue) / 100
+          );
+        } else {
+          // Get the color code from state.
+          color = state.theme.colors[colorName];
+        }
 
         // Replace the `css` prop with a new one with `color`.
         node.props.css = css`
           ${node.props.css}
-          color: ${state.theme.colors[colorName]};
+          color: ${color};
         `;
       }
     }

--- a/packages/frontity-org-theme/src/utils/index.ts
+++ b/packages/frontity-org-theme/src/utils/index.ts
@@ -1,0 +1,7 @@
+export const addAlpha = (hex, alpha) =>
+  `rgba(${hex
+    .match(/^#(.{2})(.{2})(.{2})$/)
+    .slice(1)
+    .map(value => Number(`0x${value}`))
+    .concat(alpha)
+    .join(", ")})`;

--- a/packages/frontity-org-theme/types.ts
+++ b/packages/frontity-org-theme/types.ts
@@ -34,9 +34,6 @@ interface FrontityOrg extends Package {
     html2react?: {
       processors: Html2React["libraries"]["html2react"]["processors"];
     };
-    theme: {
-      addAlpha: (hex: string, alpha: number) => string;
-    };
   };
 }
 

--- a/packages/frontity-org-theme/types.ts
+++ b/packages/frontity-org-theme/types.ts
@@ -1,5 +1,5 @@
 import { ReactType } from "react";
-import Source from "@frontity/source";
+import Source from "@frontity/source/types";
 import Router from "@frontity/router";
 import Html2React from "@frontity/html2react/types";
 import { Package } from "frontity/types";
@@ -30,8 +30,13 @@ interface FrontityOrg extends Package {
   actions: {
     theme: {};
   };
-  libraries?: {
-    html2react: Html2React["libraries"]["html2react"];
+  libraries: {
+    html2react?: Html2React["libraries"]["html2react"];
+    theme: {
+      colors: {
+        addAlpha: (hex: string, alpha: number) => string;
+      };
+    };
   };
 }
 


### PR DESCRIPTION
Modify `textColor` and `backgroundColor` processors to add colors with opacity.

Also, a function called `addAlpha` that adds an alpha channel to hex colors was added to `libraries.theme`.

Closes #3.