### PR TITLE
Add opacity to global styles colors

### DIFF
--- a/packages/frontity-org-theme/src/components/styles/global-styles.tsx
+++ b/packages/frontity-org-theme/src/components/styles/global-styles.tsx
@@ -1,5 +1,6 @@
 import { css } from "frontity";
 import FrontityOrg from "../../../types";
+import { addAlpha } from "../../utils";
 
 const cssReset = css`
   html,
@@ -61,7 +62,7 @@ const documentSetup = (colors: FrontityOrg["state"]["theme"]["colors"]) => css`
   body {
     background: ${colors.wall};
     font-family: "IBMPlexSans";
-    color: ${colors.primary[80]};
+    color: ${addAlpha(colors.primary, 0.8)};
     max-width: 1080px;
     margin: auto;
     font-size: 16px;
@@ -74,7 +75,7 @@ const documentSetup = (colors: FrontityOrg["state"]["theme"]["colors"]) => css`
   h5,
   h6 {
     font-family: "Poppins";
-    color: ${colors.primary[100]};
+    color: ${colors.primary};
   }
   img {
     max-width: 100%;
@@ -104,7 +105,7 @@ const elementBase = (colors: FrontityOrg["state"]["theme"]["colors"]) => css`
   h5 {
     font-size: 14px;
     line-height: 21px;
-    color: ${colors.primary[40]};
+    color: ${addAlpha(colors.primary, 0.4)};
     text-transform: uppercase;
   }
   ul,

--- a/packages/frontity-org-theme/src/index.ts
+++ b/packages/frontity-org-theme/src/index.ts
@@ -19,7 +19,8 @@ const frontityOrg: FrontityOrg = {
         orange: "#f4c053",
         red: "#f76d64",
         turqoise: "#6ac8c9",
-        lightgreen: "#8ACB88"
+        lightgreen: "#8ACB88",
+        white: "#ffffff"
       }
     }
   },

--- a/packages/frontity-org-theme/types.ts
+++ b/packages/frontity-org-theme/types.ts
@@ -22,6 +22,7 @@ interface FrontityOrg extends Package {
         red: string;
         turqoise: string;
         lightgreen: string;
+        white: string;
       };
     };
     source?: Source["state"]["source"];


### PR DESCRIPTION
I used the `addAlpha` util function to add opacity to some global styles and I added the white color (#FFFFFF) to `state.theme.colors`.