### PR TITLE
Move the default section css to a specific processor

### DIFF
--- a/packages/frontity-org-theme/src/components/styles/global-styles.tsx
+++ b/packages/frontity-org-theme/src/components/styles/global-styles.tsx
@@ -231,10 +231,9 @@ const documentSetup = (colors: FrontityOrg["state"]["theme"]["colors"]) => css`
   img {
     max-width: 100%;
   }
-  div#root > div > div {
+  div#root > div.wp-block-group > div {
     max-width: 1080px;
     margin: auto;
-    padding: 120px 0;
   }
 `;
 

--- a/packages/frontity-org-theme/src/index.ts
+++ b/packages/frontity-org-theme/src/index.ts
@@ -15,6 +15,7 @@ import { mobileDesktop } from "./processors/mobile-desktop";
 import { paragraph } from "./processors/paragraph";
 import { polygonBackground } from "./processors/polygon-background";
 import { scrollingSection } from "./processors/scrolling-section";
+import { section } from "./processors/section";
 import { specialIcons } from "./processors/special-icons";
 import { terminal } from "./processors/terminal";
 import { textColor } from "./processors/text-color";
@@ -71,6 +72,7 @@ const frontityOrg: FrontityOrg = {
         horizontalSeparator,
         links,
         scrollingSection,
+        section,
         specialIcons,
       ],
     },

--- a/packages/frontity-org-theme/src/processors/section.ts
+++ b/packages/frontity-org-theme/src/processors/section.ts
@@ -1,0 +1,26 @@
+import { Processor } from "@frontity/html2react/types";
+import { css } from "frontity";
+import React from "react";
+
+import FrontityOrg from "../../types";
+
+export const section: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
+  name: "section",
+  test: ({ node }) =>
+    node.type === "element" &&
+    node.props?.className?.split(" ").includes("default-section"),
+  processor: ({ node }) => {
+    if (node.type !== "element") {
+      return node;
+    }
+
+    node.props.css = css`
+      ${node.props.css};
+      > div {
+        padding: 100px 0px;
+      }
+    `;
+
+    return node;
+  },
+};


### PR DESCRIPTION
Right now, there was some css for the default sections that wasn't specific at all, and it was applying to some elements that it shouldn't. We decided to move the css of `default-section` to an specific processor. This way, we will need to add the class `default-section` where we want to apply these styles.

I've kept the `max-width` and `margin` in `global-styles` as I think it should apply to all the `<div>`s that have the class `wp-block-group` and are children of `root`. I wasn't sure if we should create a processor for that or if it's even possible to check if the parent is `div#root` with `html2react`.

I've added a `default-section' at the bottom of `/common-styles/` page to test it.