### PR TITLE
Add the intersection-observer polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1423,9 +1423,9 @@
       },
       "dependencies": {
         "@frontity/router": {
-          "version": "1.0.19",
-          "resolved": "https://registry.npmjs.org/@frontity/router/-/router-1.0.19.tgz",
-          "integrity": "sha512-VxjSZK4VSUHHR6HUczDKQNK/pbQN9iEs4AnWoi1EGZein2z4KiKt/iOc7NAoB6/jo6KLl+AhjDatjj5yg7KKnA==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@frontity/router/-/router-1.1.0.tgz",
+          "integrity": "sha512-Xc9L+c7yCHUKXWCTFroEQhUg8ijj4ZT348xaEZoLOvLDghB1hMcOOVoaidVJ88Z1V3w28WKhKuQQJVyMlu4NXQ==",
           "requires": {
             "frontity": "^1.4.3"
           }
@@ -6181,6 +6181,11 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.2"
       }
+    },
+    "intersection-observer": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.10.0.tgz",
+      "integrity": "sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ=="
     },
     "invariant": {
       "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-simple-import-sort": "^5.0.2",
     "frontity": "^1.5.3",
     "husky": "^4.2.5",
+    "intersection-observer": "^0.10.0",
     "lint-staged": "10.1.7",
     "prettier": "^2.0.5"
   }

--- a/packages/frontity-org-theme/src/index.ts
+++ b/packages/frontity-org-theme/src/index.ts
@@ -1,4 +1,6 @@
 import "./prism";
+// load the polyfill for `intersection-observer`
+import "intersection-observer";
 
 import iframe from "@frontity/html2react/processors/iframe";
 


### PR DESCRIPTION
This fixes #100 .

The polyfill is needed because some browsers (most notably Safari < 11) do not ship with `IntersectionObserver` API