### PR TITLE
Change header slug

### DIFF
--- a/.changeset/violet-pets-speak.md
+++ b/.changeset/violet-pets-speak.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Change the header slug to match the Gutenberg side.

--- a/packages/frontity-org-theme/src/components/headers/index.tsx
+++ b/packages/frontity-org-theme/src/components/headers/index.tsx
@@ -10,7 +10,7 @@ import { fixedHeaderStyles, headerStyles } from "./header-styles";
 export const Header = connect<React.FC<Connect<FrontityOrg>>>(
   ({ state, actions, libraries }) => {
     // Get the header template.
-    const data = state.source.get("/blog/wp_template_part/header/");
+    const data = state.source.get("/blog/wp_template_part/header-web/");
     const header = state.source["wp_template_part"][data.id];
 
     // Get the component that transform the template to React.

--- a/packages/frontity-org-theme/src/state/index.ts
+++ b/packages/frontity-org-theme/src/state/index.ts
@@ -17,7 +17,7 @@ const state: FrontityOrg["state"]["theme"] = {
   },
 
   // slugs for the WP templates that are fetched in BeforeSSR
-  templates: ["fixed-header", "header", "footer", "newsletter"],
+  templates: ["fixed-header", "header-web", "footer", "newsletter"],
 
   // Used in the frontity-flow section of the homepage
   flowSectionActiveTab: 1,


### PR DESCRIPTION
The slug of the header has been changed from Gutenberg so it has to match in Frontity.