### PR TITLE
Add z-index prop to second background of the hero

### DIFF
--- a/.changeset/selfish-dogs-drive.md
+++ b/.changeset/selfish-dogs-drive.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Add z-index prop to the second background of the hero to solve overlaying problems when clip-path is not applied.

--- a/packages/frontity-org-theme/src/components/styles/homepage.tsx
+++ b/packages/frontity-org-theme/src/components/styles/homepage.tsx
@@ -53,7 +53,7 @@ const homePageStyles = (state: FrontityOrg["state"]["theme"]) => css`
       top: 0;
       height: 100%;
       width: 100%;
-
+      z-index: -1;
       clip-path: polygon(0 100%, 100% 85%, 100% 92%);
     }
 


### PR DESCRIPTION
As the `clip-path` prop is not supported by most of the versions of Microsoft Edge, it's not being applied, and the second background of the homepage hero is being placed over the main one. Just by adding the `z-index` prop the problem seems to be solved.