### PR TITLE
Add processors needed for lazy loading tweets

### DIFF
--- a/.changeset/quick-bulldogs-hide.md
+++ b/.changeset/quick-bulldogs-hide.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": minor
+---
+
+Add lazy load to the tweets so we can improve the performance of the web.

--- a/packages/frontity-org-theme/src/components/tweet.tsx
+++ b/packages/frontity-org-theme/src/components/tweet.tsx
@@ -1,0 +1,24 @@
+import Script from "@frontity/components/script";
+import useInView from "@frontity/hooks/use-in-view";
+import { Connect, Package } from "frontity/types";
+import React from "react";
+
+type TweetType = React.FC<Connect<Package, any>>;
+
+const Tweet: TweetType = ({ children, ...props }) => {
+  const { ref, inView } = useInView({
+    rootMargin: "600px",
+    triggerOnce: true,
+  });
+
+  return (
+    <>
+      <blockquote ref={ref} {...props}>
+        {children}
+      </blockquote>
+      {inView && <Script src="https://platform.twitter.com/widgets.js" />}
+    </>
+  );
+};
+
+export default Tweet;

--- a/packages/frontity-org-theme/src/index.ts
+++ b/packages/frontity-org-theme/src/index.ts
@@ -35,6 +35,8 @@ import { section } from "./processors/section";
 import { specialIcons } from "./processors/special-icons";
 import { terminal } from "./processors/terminal";
 import { textColor } from "./processors/text-color";
+import { addTweet } from "./processors/tweets/add-tweet";
+import { deleteTwitterScript } from "./processors/tweets/delete-script";
 import { typingProcessor } from "./processors/typingProcessor";
 import state from "./state";
 
@@ -82,6 +84,8 @@ const frontityOrg: FrontityOrg = {
         homepageHeroAnimation,
         typingProcessor,
         heroBlogImage,
+        addTweet,
+        deleteTwitterScript,
       ],
     },
   },

--- a/packages/frontity-org-theme/src/processors/tweets/add-tweet.ts
+++ b/packages/frontity-org-theme/src/processors/tweets/add-tweet.ts
@@ -1,0 +1,17 @@
+import { Element,Processor } from "@frontity/html2react/types";
+
+import Tweet from "../../components/tweet";
+
+export const addTweet: Processor<Element> = {
+  test: ({ node }) =>
+    node.type === "element" &&
+    node.component === "blockquote" &&
+    (node.props.className.split(" ").includes("twitter-tweet") ||
+      node.props.className.split(" ").includes("twitter-video")),
+  priority: 10,
+  name: "addTweet",
+  processor: ({ node }) => {
+    node.component = Tweet;
+    return node;
+  },
+};

--- a/packages/frontity-org-theme/src/processors/tweets/delete-script.ts
+++ b/packages/frontity-org-theme/src/processors/tweets/delete-script.ts
@@ -1,0 +1,13 @@
+import { Element,Processor } from "@frontity/html2react/types";
+
+export const deleteTwitterScript: Processor<Element> = {
+  test: ({ node }) =>
+    node.type === "element" &&
+    node.component === "script" &&
+    node.props.src.includes("platform.twitter.com"),
+  priority: 10,
+  name: "deleteTwitterScript",
+  processor: () => {
+    return null;
+  },
+};


### PR DESCRIPTION
This is a Pull Request to lazy load the tweets in the homepage so we can improve the performance of the web. I've added two different processors:
- One to remove the Twitter scripts found in the content.
- Another one to include them once the tweet is `inView`.

I'm not sure if I used TypeScript correctly, but Visual Studio wasn't complaining.