### PR TITLE
Add processor to lazy load the videos

### DIFF
--- a/.changeset/hip-poems-wonder.md
+++ b/.changeset/hip-poems-wonder.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": minor
+---
+
+Add processor to lazy load the videos and improve the performance of the web.

--- a/packages/frontity-org-theme/src/components/lazy-video.tsx
+++ b/packages/frontity-org-theme/src/components/lazy-video.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/media-has-caption */
+
 import useInView from "@frontity/hooks/use-in-view";
 import { Connect, Package } from "frontity/types";
 import React from "react";

--- a/packages/frontity-org-theme/src/components/lazy-video.tsx
+++ b/packages/frontity-org-theme/src/components/lazy-video.tsx
@@ -1,0 +1,22 @@
+import useInView from "@frontity/hooks/use-in-view";
+import { Connect, Package } from "frontity/types";
+import React from "react";
+
+type VideoType = React.FC<Connect<Package, any>>;
+
+const LazyVideo: VideoType = ({ children, ...props }) => {
+  const { ref, inView } = useInView({
+    rootMargin: "600px",
+    triggerOnce: true,
+  });
+
+  return (
+    <>
+      <video ref={ref} {...(inView && props)}>
+        {children}
+      </video>
+    </>
+  );
+};
+
+export default LazyVideo;

--- a/packages/frontity-org-theme/src/index.ts
+++ b/packages/frontity-org-theme/src/index.ts
@@ -36,6 +36,8 @@ import { specialIcons } from "./processors/special-icons";
 import { terminal } from "./processors/terminal";
 import { textColor } from "./processors/text-color";
 import { typingProcessor } from "./processors/typingProcessor";
+import { lazyVideo } from "./processors/lazy-video";
+
 import state from "./state";
 
 const frontityOrg: FrontityOrg = {
@@ -82,6 +84,7 @@ const frontityOrg: FrontityOrg = {
         homepageHeroAnimation,
         typingProcessor,
         heroBlogImage,
+        lazyVideo,
       ],
     },
   },

--- a/packages/frontity-org-theme/src/processors/lazy-video.ts
+++ b/packages/frontity-org-theme/src/processors/lazy-video.ts
@@ -1,0 +1,12 @@
+import { Processor, Element } from "@frontity/html2react/types";
+import LazyVideo from "../components/lazy-video";
+
+export const lazyVideo: Processor<Element> = {
+  name: "lazy-video",
+  test: ({ node }) => node.type === "element" && node.component === "video",
+  processor: ({ node }) => {
+    node.component = LazyVideo;
+
+    return node;
+  },
+};


### PR DESCRIPTION
In order to improve the performance, we want to lazy load the videos of the web. There's a video in the homepage named `LiveContentUpdate` where we can check this.