### PR TITLE
Change urls to point to frontity.org instead of wp.frontity.org

### DIFF
--- a/.changeset/dull-suits-sell.md
+++ b/.changeset/dull-suits-sell.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Change url of the urls pointing to wp.frontity.org to frontity.org directly.

--- a/frontity.settings.js
+++ b/frontity.settings.js
@@ -16,7 +16,7 @@ const settings = [
         name: "@frontity/wp-source",
         state: {
           source: {
-            api: "https://wp.frontity.org/wp-json",
+            api: "https://frontity.org/wp-json",
             postTypes: [
               {
                 type: "/blog/wp_template_part",
@@ -103,7 +103,7 @@ const settings = [
         name: "@frontity/wp-source",
         state: {
           source: {
-            api: "https://wp.frontity.org/wp-json",
+            api: "https://frontity.org/wp-json",
             homepage: "/homepage/",
             postsPage: "/blog",
             categoryBase: "/blog/category",

--- a/packages/frontity-org-theme/src/processors/checklists.ts
+++ b/packages/frontity-org-theme/src/processors/checklists.ts
@@ -23,7 +23,7 @@ export const checklists: Processor<React.HTMLProps<HTMLElement>> = {
               display: flex;
 
               &:before {
-                content: url("https://wp.frontity.org/wp-content/uploads/2020/02/check-circle-marker.svg");
+                content: url("https://frontity.org/wp-content/uploads/2020/02/check-circle-marker.svg");
               }
             }
           `,


### PR DESCRIPTION
As we have moved our backend to `frontity.org`, we should update the urls pointing to the old one, even though it's redirected.