### PR TITLE
Bold elements

### DIFF
--- a/.changeset/clever-toes-battle.md
+++ b/.changeset/clever-toes-battle.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Add font-weight bold to strong elements.

--- a/packages/frontity-org-theme/src/components/styles/global-styles.tsx
+++ b/packages/frontity-org-theme/src/components/styles/global-styles.tsx
@@ -209,6 +209,10 @@ const cssReset = css`
   [hidden] {
     display: none;
   }
+  strong,
+  b {
+    font-weight: bold;
+  }
 `;
 
 const documentSetup = (colors: FrontityOrg["state"]["theme"]["colors"]) => css`


### PR DESCRIPTION
Right now, the `<strong>` and `<b>` elements, that Gutenberg is using for the bold elements, are not working correctly. I added them to the global styles to make them work.