### PR TITLE
Adapt links processor to new Gutenberg version (8.4)

### DIFF
--- a/.changeset/shaggy-singers-tickle.md
+++ b/.changeset/shaggy-singers-tickle.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Adapt links processor to new Gutenberg version.

--- a/packages/frontity-org-theme/src/processors/frontity-flow-button.tsx
+++ b/packages/frontity-org-theme/src/processors/frontity-flow-button.tsx
@@ -32,7 +32,7 @@ export const flowButton: Processor<
       component: FlowButton,
       props: {
         tabNumber: parseInt(tabNumber),
-        text: (node as any).children[1]?.content,
+        text: (node as any).children[0].children[0]?.content,
       },
     };
   },

--- a/packages/frontity-org-theme/src/processors/links-buttons.tsx
+++ b/packages/frontity-org-theme/src/processors/links-buttons.tsx
@@ -17,11 +17,13 @@ export const links: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
     const isButton = node.props?.className
       ?.split(/ /)
       .includes("wp-block-button__link");
-    const isBig = node.props?.className?.split(/ /).includes("button-big");
-    const isButtonText = node.props?.className
+    const isBig = node.parent.props?.className
+      ?.split(/ /)
+      .includes("button-big");
+    const isButtonText = node.parent.props?.className
       ?.split(/ /)
       .includes("button-text");
-    const noLogo = node.props?.className?.split(/ /).includes("no-logo");
+    const noLogo = node.parent.props?.className?.split(/ /).includes("no-logo");
     const hasImage = (node as any).children.some(
       (child) => child.type === "element" && child.component === "img"
     );
@@ -113,7 +115,10 @@ export const links: Processor<React.HTMLProps<HTMLElement>, FrontityOrg> = {
           padding: 12px 18px;
           color: ${state.theme.colors.frontity};
           background-color: transparent;
-          &:hover {
+          &:hover,
+          &:active,
+          &:focus,
+          &:visited {
             color: ${state.theme.colors.frontity};
           }
           &:hover::after {


### PR DESCRIPTION
The new version of the Gutenberg plugin changes the html format of the links, so we need to adapt our processor to match this html. It's adding a parent `<div>`, which is the one receiving the classes added from the WordPress dashboard. In order to adapt it, I added a check for the `node.parent` instead of just `node`.

## Previous HTML

```
<a class="wp-block-button wp-block-button__link button-text" href="https://docs.frontity.org/getting-started/" >Learn more</a>
```

## New HTML

```
<div class="wp-block-button button-text">
  <a class="wp-block-button__link" href="https://docs.frontity.org/getting-started/" >Learn more</a>
</div>
```

As we don't have the latest version in our current web (it would break some things), we can test it pointing the project to https://snippets-frontity-org.pantheonsite.io/, where we have installed Gutenberg 8.4 version.