### PR TITLE
Add support for center alignment from Gutenberg in our blog

### DIFF
--- a/.changeset/hip-turtles-share.md
+++ b/.changeset/hip-turtles-share.md
@@ -1,0 +1,5 @@
+---
+"@frontity/twentytwenty-theme": patch
+---
+
+Add support for center alignment from Gutenberg.

--- a/packages/twentytwenty-theme/src/components/styles/global-styles.js
+++ b/packages/twentytwenty-theme/src/components/styles/global-styles.js
@@ -373,6 +373,9 @@ const mediaStyle = (colors) => css`
     display: block;
     margin: 0;
   }
+  figure.aligncenter img {
+    margin: auto;
+  }
 
   iframe {
     display: block;


### PR DESCRIPTION
Right now, it isn't possible to center align the images in our blog. As we are using Gutenberg, it is adding the class `aligncenter` if you select so from the WordPress editor, but we don't have css logic to match that, so I added it.