### PR TITLE
Fallback to sans-serif

### DIFF
--- a/.changeset/good-news-teach.md
+++ b/.changeset/good-news-teach.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": minor
+---
+
+Add fallback to sans-serif for custom fonts.

--- a/packages/frontity-org-theme/src/components/styles/global-styles.tsx
+++ b/packages/frontity-org-theme/src/components/styles/global-styles.tsx
@@ -218,7 +218,7 @@ const cssReset = css`
 const documentSetup = (colors: FrontityOrg["state"]["theme"]["colors"]) => css`
   body {
     background: ${colors.wall};
-    font-family: "IBMPlexSans";
+    font-family: "IBMPlexSans", Sans-Serif;
     color: ${addAlpha(colors.primary, 0.8)};
     font-size: 16px;
     line-height: 24px;
@@ -230,7 +230,7 @@ const documentSetup = (colors: FrontityOrg["state"]["theme"]["colors"]) => css`
   h4,
   h5,
   h6 {
-    font-family: "Poppins";
+    font-family: "Poppins", Sans-Serif;
     color: ${colors.primary};
   }
   img {


### PR DESCRIPTION
These are the custom fonts:

<img src="https://user-images.githubusercontent.com/3305402/100754183-0c340900-33eb-11eb-897a-c60429831cfe.png" width="300" />

But before the fonts are loaded (or if they are not loaded at all) they default to "serif", which is the browser's default, at least on macOS.

So it looks like this:

<img src="https://user-images.githubusercontent.com/3305402/100754327-41d8f200-33eb-11eb-80e8-c4e7c0f7c227.png" width="300" />

This PR adds "sans-serif" as a fallback, so it will look like this:

<img src="https://user-images.githubusercontent.com/3305402/100754384-56b58580-33eb-11eb-9ceb-68b3e26563da.png" width="300" />

It will still flash, but it is more similar.