### PR TITLE
Use a blue background color

### DIFF
--- a/frontity.settings.js
+++ b/frontity.settings.js
@@ -90,7 +90,7 @@ const settings = [
               primary: "#4d6bee",
               headerBg: "#ffffff",
               footerBg: "#ffffff",
-              bodyBg: "#ffffff",
+              bodyBg: "#f2f3fc",
             },
             // Whether to show the search button in page header
             showSearchInHeader: true,

--- a/frontity.settings.js
+++ b/frontity.settings.js
@@ -87,7 +87,7 @@ const settings = [
               ["Twitter", "https://twitter.com/frontity"],
             ],
             colors: {
-              primary: "#4d6bee",
+              primary: "#0f1c64",
               headerBg: "#ffffff",
               footerBg: "#ffffff",
               bodyBg: "#f2f3fc",


### PR DESCRIPTION
While working on https://frontityengine.wpengine.com/ I noticed that adding a light blue background color to the twentytwenty-theme feels quite nice. In my opinion, our white-only theme feels kind of dry compared.

So I added the light blue of https://frontity.org.

I have opened this PR so we have a URL to compare with but I will ask the team about their opinion.