### PR TITLE
Update the tiny-router to latest version & install the @frontity/components package

### DIFF
--- a/.changeset/small-donuts-cover.md
+++ b/.changeset/small-donuts-cover.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Bump the version of tiny-router and install the @frontity/components package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1499,17 +1499,6 @@
         }
       }
     },
-    "@frontity/components": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@frontity/components/-/components-1.5.1.tgz",
-      "integrity": "sha512-QoA2qA9BywdEfyLpDhgAMXq0Q1rQgwHN1ywj8s8SB9o63jgJ1IRKSjAmvNI96HkbzMfCsA3bDKFpkgpQzlcX5w==",
-      "requires": {
-        "@frontity/hooks": "^2.0.2",
-        "@frontity/router": "^1.1.1",
-        "@frontity/source": "^1.2.2",
-        "frontity": "^1.10.1"
-      }
-    },
     "@frontity/connect": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@frontity/connect/-/connect-1.1.4.tgz",
@@ -1679,6 +1668,24 @@
         "react-intersection-observer": "^8.30.3",
         "react-typist": "^2.0.5",
         "use-media": "^1.4.0"
+      },
+      "dependencies": {
+        "@frontity/router": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@frontity/router/-/router-1.1.2.tgz",
+          "integrity": "sha512-qLfde061ZfO29sBOQC9FepknLD1HfoaS4XOcIQh45nCKlAChDZ+hDlSyOKtwyK3aLlk5oTTV23/LLqUuLWwNWw==",
+          "requires": {
+            "frontity": "^1.13.0"
+          }
+        },
+        "@frontity/source": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@frontity/source/-/source-1.4.0.tgz",
+          "integrity": "sha512-m0y+2TI82Hp1E6kSBzg0qiS75gfNM4czBNPP1sIeiRZTtdYeWMAY0GYdrXWbP09dNT7qROs4XdxW+7sSyd9pUw==",
+          "requires": {
+            "frontity": "^1.13.0"
+          }
+        }
       }
     },
     "@frontity/google-tag-manager-analytics": {
@@ -1765,26 +1772,10 @@
         }
       }
     },
-    "@frontity/router": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@frontity/router/-/router-1.1.1.tgz",
-      "integrity": "sha512-N/+jPyOjnH7zgepl23MWkD4pJ5rYvPI47pASzD2dOqHRCSovgMaZrpqQfEQqo/ZmczZfm1MiBbZKukVK5u5DIQ==",
-      "requires": {
-        "frontity": "^1.9.0"
-      }
-    },
-    "@frontity/source": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@frontity/source/-/source-1.3.1.tgz",
-      "integrity": "sha512-Xt5xm+60gTxNXdDGydAS9MtXBt5kr6IPtRONP0xTD/seogYCWVLEYlQv0e8ypXxrYY2xtgXQdRaNOOqaYVagcw==",
-      "requires": {
-        "frontity": "^1.12.0"
-      }
-    },
     "@frontity/tiny-router": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@frontity/tiny-router/-/tiny-router-1.2.3.tgz",
-      "integrity": "sha512-ag33LO0osfRYG6pSbYzMhcNyZpv4/iW2y0glls56YsnS0tNSCEEAW5ulwYKKUB1zpOX2z0KGJf85nvGZIKSR/w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@frontity/tiny-router/-/tiny-router-1.2.4.tgz",
+      "integrity": "sha512-BtxngCKTyQJZsQj7noOQx3a1Nfg3niSo6eIfAwcdVXybIXWutdNlkI+Z2jJPRccHpPg7mKcd/M31JN6nHf8juw==",
       "requires": {
         "@frontity/router": "^1.1.2",
         "@frontity/source": "^1.4.0",
@@ -1817,6 +1808,35 @@
         "frontity": "^1.13.0",
         "react-spinners": "^0.9.0",
         "react-spring": "^8.0.27"
+      },
+      "dependencies": {
+        "@frontity/components": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@frontity/components/-/components-1.6.0.tgz",
+          "integrity": "sha512-YyGR/o8i49532fASkdpQp2nMKq/MNU1uVGwi/6yDVIm9bm69T5GYoqDGQ0v4d8Mif8NXDjlioo1y1u2j8vBNhg==",
+          "requires": {
+            "@frontity/hooks": "^2.0.2",
+            "@frontity/router": "^1.1.2",
+            "@frontity/source": "^1.4.0",
+            "frontity": "^1.13.0"
+          }
+        },
+        "@frontity/router": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@frontity/router/-/router-1.1.2.tgz",
+          "integrity": "sha512-qLfde061ZfO29sBOQC9FepknLD1HfoaS4XOcIQh45nCKlAChDZ+hDlSyOKtwyK3aLlk5oTTV23/LLqUuLWwNWw==",
+          "requires": {
+            "frontity": "^1.13.0"
+          }
+        },
+        "@frontity/source": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@frontity/source/-/source-1.4.0.tgz",
+          "integrity": "sha512-m0y+2TI82Hp1E6kSBzg0qiS75gfNM4czBNPP1sIeiRZTtdYeWMAY0GYdrXWbP09dNT7qROs4XdxW+7sSyd9pUw==",
+          "requires": {
+            "frontity": "^1.13.0"
+          }
+        }
       }
     },
     "@frontity/type-declarations": {
@@ -3676,6 +3696,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -6122,6 +6151,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "3.6.1",
@@ -9630,6 +9665,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -12845,7 +12886,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1499,6 +1499,17 @@
         }
       }
     },
+    "@frontity/components": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@frontity/components/-/components-1.6.0.tgz",
+      "integrity": "sha512-YyGR/o8i49532fASkdpQp2nMKq/MNU1uVGwi/6yDVIm9bm69T5GYoqDGQ0v4d8Mif8NXDjlioo1y1u2j8vBNhg==",
+      "requires": {
+        "@frontity/hooks": "^2.0.2",
+        "@frontity/router": "^1.1.2",
+        "@frontity/source": "^1.4.0",
+        "frontity": "^1.13.0"
+      }
+    },
     "@frontity/connect": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@frontity/connect/-/connect-1.1.4.tgz",
@@ -1661,6 +1672,7 @@
     "@frontity/frontity-org-theme": {
       "version": "file:packages/frontity-org-theme",
       "requires": {
+        "@frontity/components": "^1.6.0",
         "@frontity/html2react": "^1.5.0",
         "@frontity/router": "^1.1.2",
         "@frontity/source": "^1.4.0",
@@ -1770,6 +1782,22 @@
             "frontity": "^1.13.0"
           }
         }
+      }
+    },
+    "@frontity/router": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@frontity/router/-/router-1.1.2.tgz",
+      "integrity": "sha512-qLfde061ZfO29sBOQC9FepknLD1HfoaS4XOcIQh45nCKlAChDZ+hDlSyOKtwyK3aLlk5oTTV23/LLqUuLWwNWw==",
+      "requires": {
+        "frontity": "^1.13.0"
+      }
+    },
+    "@frontity/source": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@frontity/source/-/source-1.4.0.tgz",
+      "integrity": "sha512-m0y+2TI82Hp1E6kSBzg0qiS75gfNM4czBNPP1sIeiRZTtdYeWMAY0GYdrXWbP09dNT7qROs4XdxW+7sSyd9pUw==",
+      "requires": {
+        "frontity": "^1.13.0"
       }
     },
     "@frontity/tiny-router": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@frontity/frontity-org-theme": "file:packages/frontity-org-theme",
     "@frontity/google-tag-manager-analytics": "^1.1.1",
     "@frontity/html2react": "^1.5.0",
-    "@frontity/tiny-router": "^1.2.3",
+    "@frontity/tiny-router": "^1.2.4",
     "@frontity/twentytwenty-theme": "file:packages/twentytwenty-theme",
     "@frontity/wp-source": "^1.10.0",
     "@frontity/yoast": "^2.0.1",

--- a/packages/frontity-org-theme/package.json
+++ b/packages/frontity-org-theme/package.json
@@ -9,6 +9,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "@frontity/components": "^1.6.0",
     "@frontity/html2react": "^1.5.0",
     "@frontity/source": "^1.4.0",
     "@frontity/router": "^1.1.2",


### PR DESCRIPTION
This updates the tiny-router to `1.2.4` which includes the fix for "link mismatch": https://github.com/frontity/frontity/pull/634 that is needed for `?utm_*` links to work in our Pantheon hosting because of https://pantheon.io/docs/pantheon_stripped.

I have also installed the `@frontity/components` package in the `@frontity/frontity-org-theme` which was mysteriously missing, thus preventing the project from building.

