### PR TITLE
Fix featured image in blog posts not showing properly in mobile

### DIFF
--- a/.changeset/fuzzy-experts-share.md
+++ b/.changeset/fuzzy-experts-share.md
@@ -1,0 +1,5 @@
+---
+"@frontity/twentytwenty-theme": patch
+---
+
+Fix feature image in blog posts not showing correctly on mobile.

--- a/packages/twentytwenty-theme/src/components/post/featured-media.js
+++ b/packages/twentytwenty-theme/src/components/post/featured-media.js
@@ -40,7 +40,6 @@ export default connect(FeaturedMedia);
 const Figure = styled.figure`
   margin-top: 5rem;
   position: relative;
-  min-height: 300px;
 
   @media (min-width: 700px) {
     margin-top: 6rem;


### PR DESCRIPTION
As explained in [this issue](https://github.com/frontity/frontity/issues/278#issuecomment-577636071), the featured images in mobile are not showing correctly and they have some space they shouldn't. I've removed the `min-height` of the `<figure>` element as I think that is the problem.