### PR TITLE
Move submenu styles out of is-link-with-icon

### DIFF
--- a/.changeset/fresh-frogs-smoke.md
+++ b/.changeset/fresh-frogs-smoke.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Move submenu styles out of is-link-with icon.

--- a/packages/frontity-org-theme/src/components/headers/header-styles.ts
+++ b/packages/frontity-org-theme/src/components/headers/header-styles.ts
@@ -138,10 +138,10 @@ export const desktopStyles = ({ state }: { state: State<FrontityOrg> }) =>
         /* Margins for links with icons */
         &.is-link-with-icon {
           margin-left: 16px;
-          /* Tooltip styles */
-          &.has-child > .wp-block-navigation__container {
-            ${tooltipStyles({ state })};
-          }
+        }
+        /* Tooltip styles */
+        &.has-child > .wp-block-navigation__container {
+          ${tooltipStyles({ state })};
         }
 
         .wp-block-navigation-link__content {


### PR DESCRIPTION
Right now, if we want to add a submenu in any of the header links, it just works for the icons. I moved the styles out of the `is-list-with-icon` class to make it work in the other links.

**Previously**
![Screenshot from 2021-02-05 09-09-39](https://user-images.githubusercontent.com/34552881/107007411-cc92f000-6792-11eb-8932-1594609f0b3c.png)

**After**
![Screenshot from 2021-02-05 09-15-53](https://user-images.githubusercontent.com/34552881/107007434-d288d100-6792-11eb-98cb-8c916d9073e6.png)

