### PR TITLE
Remove opacity definition to avoid background transparency

### DIFF
--- a/.changeset/purple-nails-breathe.md
+++ b/.changeset/purple-nails-breathe.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Remove opacity definition to avoid background transparency

--- a/packages/frontity-org-theme/src/components/styles/homepage.tsx
+++ b/packages/frontity-org-theme/src/components/styles/homepage.tsx
@@ -15,9 +15,6 @@ const homePageStyles = (state: FrontityOrg["state"]["theme"]) => css`
     }
   }
 
-  ul {
-    opacity: 0.85;
-  }
   /* Top section */
   .top-section {
     position: relative;


### PR DESCRIPTION
To avoid this effect

<img width="454" alt="Captura de pantalla 2021-02-22 a las 13 04 48" src="https://user-images.githubusercontent.com/422576/108729610-01d96500-752b-11eb-9340-3d36c1b749eb.png">
