### PR TITLE
Join isLimit and isError statements to prevent duplication

### DIFF
--- a/.changeset/lovely-keys-admire.md
+++ b/.changeset/lovely-keys-admire.md
@@ -1,0 +1,5 @@
+---
+"@frontity/twentytwenty-theme": patch
+---
+
+Join isLimit and isError statements in Infinite Scroll hooks.

--- a/packages/twentytwenty-theme/src/components/archive/archive.js
+++ b/packages/twentytwenty-theme/src/components/archive/archive.js
@@ -25,17 +25,10 @@ const Archive = ({ state }) => {
         </Wrapper>
       ))}
       {isFetching && <Loading />}
-      {isLimit && (
+      {(isLimit || isError) && (
         <ButtonContainer>
           <Button bg={primary} onClick={fetchNext}>
-            Load more
-          </Button>
-        </ButtonContainer>
-      )}
-      {isError && (
-        <ButtonContainer>
-          <Button bg={primary} onClick={fetchNext}>
-            Something failed - Retry
+            {isError ? "Something failed - Retry" : "Load More"}
           </Button>
         </ButtonContainer>
       )}

--- a/packages/twentytwenty-theme/src/components/post/post-list.js
+++ b/packages/twentytwenty-theme/src/components/post/post-list.js
@@ -34,17 +34,10 @@ const PostList = ({ state, actions }) => {
         </Wrapper>
       ))}
       {isFetching && <Loading />}
-      {isLimit && (
+      {(isLimit || isError) && (
         <ButtonContainer>
           <Button bg={primary} onClick={fetchNext}>
-            Load more
-          </Button>
-        </ButtonContainer>
-      )}
-      {isError && (
-        <ButtonContainer>
-          <Button bg={primary} onClick={fetchNext}>
-            Something failed - Retry
+            {isError ? "Something failed - Retry" : "Load More"}
           </Button>
         </ButtonContainer>
       )}


### PR DESCRIPTION
As explained in [this comment](https://community.frontity.org/t/infinite-scroll-hooks/2055/38?u=santosguillamot), we should ensure that `isLimit` and `isError` buttons aren't duplicated.