### PR TITLE
Add a `min-height` prop to images inside web-browser component

### DIFF
--- a/.changeset/brave-bikes-knock.md
+++ b/.changeset/brave-bikes-knock.md
@@ -1,0 +1,7 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Add a workaround for some lazy-loaded images not being shown in Chrome.
+
+These images are rendered inside a web-browser component, in the "Get some inspiration" section of the "/learn/" page.

--- a/packages/frontity-org-theme/src/processors/web-browser.tsx
+++ b/packages/frontity-org-theme/src/processors/web-browser.tsx
@@ -42,7 +42,10 @@ export const webBrowser: Processor<Element> = {
       iframe,
       video {
         display: block;
-        /* Required for some lazy-loaded elements to be shown */
+      }
+
+      /* Required for some lazy-loaded elements to be shown in Chrome */
+      [loading="lazy"] {
         min-height: 1px;
       }
     `;

--- a/packages/frontity-org-theme/src/processors/web-browser.tsx
+++ b/packages/frontity-org-theme/src/processors/web-browser.tsx
@@ -42,6 +42,8 @@ export const webBrowser: Processor<Element> = {
       iframe,
       video {
         display: block;
+        /* Required for some lazy-loaded elements to be shown */
+        min-height: 1px;
       }
     `;
 


### PR DESCRIPTION
This PR fixes an issue in the [https://frontity.org/learn/](https://frontity.org/learn/) page, in the "Get some inspiration" section, related to some lazy-loaded images not being shown.

It seems to be a bug that happens only in the Chrome browser (tested in versions 90 and 91).

The fix is just a workaround making those images to have a minimun height of 1px. That way, Chrome seems to handle them correctly.