### PR TITLE
Fix top banner

### DIFF
--- a/.changeset/metal-tips-sip.md
+++ b/.changeset/metal-tips-sip.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Fix top banner error.

--- a/packages/frontity-org-theme/src/components/top-banner.tsx
+++ b/packages/frontity-org-theme/src/components/top-banner.tsx
@@ -4,23 +4,21 @@ import React from "react";
 
 import FrontityOrg from "../../types";
 
-const TopBanner = connect<React.FC<Connect<FrontityOrg>>>(
-  ({ state, libraries }) => {
-    // Get the banner template.
-    const data = state.source.get("/blog/wp_template_part/top-banner/");
-    const banner = state.source["wp_template_part"][data.id];
+const TopBanner: React.FC<Connect<FrontityOrg>> = ({ state, libraries }) => {
+  // Get the banner template.
+  const data = state.source.get("/blog/wp_template_part/top-banner/");
+  const banner = state.source["wp_template_part"][data.id];
 
-    // Get the component that transform the template to React.
-    const Html2React = libraries.html2react.Component;
+  // Get the component that transform the template to React.
+  const Html2React = libraries.html2react.Component;
 
-    return (
-      <Container>
-        {/* Render the template */}
-        <Html2React html={banner.content.rendered} />
-      </Container>
-    );
-  }
-);
+  return (
+    <Container>
+      {/* Render the template */}
+      <Html2React html={banner.content.rendered} />
+    </Container>
+  );
+};
 
 export default connect(TopBanner);
 


### PR DESCRIPTION
We have an option to activate/deactivate a top banner in the web through template parts. Currently, if we activate it, it returns an Internal Server Error. This change aims to fix it.