### PR TITLE
Fix errors after 5.9 update

### DIFF
--- a/.changeset/olive-colts-fry.md
+++ b/.changeset/olive-colts-fry.md
@@ -1,0 +1,5 @@
+---
+"@frontity/frontity-org-theme": patch
+---
+
+Change template parts urls and css of the navigation block.

--- a/frontity.settings.js
+++ b/frontity.settings.js
@@ -27,7 +27,7 @@ const settings = [
           source: {
             postTypes: [
               {
-                type: "/blog/wp_template_part",
+                type: "/blog",
                 endpoint: "template-parts",
               },
               {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18213,7 +18213,7 @@
     },
     "packages/frontity-org-theme": {
       "name": "@frontity/frontity-org-theme",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@frontity/components": "^1.8.0",

--- a/packages/frontity-org-theme/src/actions.ts
+++ b/packages/frontity-org-theme/src/actions.ts
@@ -3,19 +3,19 @@ import FrontityOrg from "../types";
 const actions: FrontityOrg["actions"]["theme"] = {
   beforeSSR: async ({ state, actions }) => {
     await Promise.all(
-      state.theme.templates.map((slug) =>
-        actions.source.fetch(`/blog/wp_template_part/${slug}`)
-      )
+      state.theme.templates.map((slug) => actions.source.fetch(`/blog/${slug}`))
     );
     // Check if top banner should be visible
-    const banner = state.source.get("/blog/wp_template_part/top-banner/");
+    const banner = state.source.get("/blog/top-banner/");
     state.theme.isTopBannerVisible = banner.isError
       ? false
       : state.source["wp_template_part"][banner.id].acf.visible === "true";
   },
-  setFlowSectionActiveTab: ({ state }) => ({ tabNumber }) => {
-    state.theme.flowSectionActiveTab = tabNumber;
-  },
+  setFlowSectionActiveTab:
+    ({ state }) =>
+    ({ tabNumber }) => {
+      state.theme.flowSectionActiveTab = tabNumber;
+    },
   showFixedHeader: ({ state }) => {
     state.theme.isFixedHeaderVisible = true;
   },
@@ -50,21 +50,29 @@ const actions: FrontityOrg["actions"]["theme"] = {
     state.theme.newsletter.sent.afterNewsletter = true;
   },
 
-  setAnswer: ({ state }) => ({ name, answer }) => {
-    state.theme.newsletter.afterNewsletter.answers[name] = answer;
-  },
+  setAnswer:
+    ({ state }) =>
+    ({ name, answer }) => {
+      state.theme.newsletter.afterNewsletter.answers[name] = answer;
+    },
 
-  setNewsletterPropString: ({ state }) => ({ name, value }) => {
-    state.theme.newsletter.newsletterForm[name] = value;
-  },
+  setNewsletterPropString:
+    ({ state }) =>
+    ({ name, value }) => {
+      state.theme.newsletter.newsletterForm[name] = value;
+    },
 
-  setNewsletterPropBoolean: ({ state }) => ({ name, value }) => {
-    state.theme.newsletter.newsletterForm[name] = value;
-  },
+  setNewsletterPropBoolean:
+    ({ state }) =>
+    ({ name, value }) => {
+      state.theme.newsletter.newsletterForm[name] = value;
+    },
 
-  setAfterNewsletterProp: ({ state }) => ({ name, value }) => {
-    state.theme.newsletter.afterNewsletter[name] = value;
-  },
+  setAfterNewsletterProp:
+    ({ state }) =>
+    ({ name, value }) => {
+      state.theme.newsletter.afterNewsletter[name] = value;
+    },
   loadHeroBlog: ({ state, actions }) => {
     state.theme.heroBlogIsLoading = !state.theme.heroBlogIsLoading;
     actions.theme.setHeroTerminalPosition();

--- a/packages/frontity-org-theme/src/components/footer.tsx
+++ b/packages/frontity-org-theme/src/components/footer.tsx
@@ -6,7 +6,7 @@ import FrontityOrg from "../../types";
 import { addAlpha } from "../utils";
 
 const Footer: React.FC<Connect<FrontityOrg>> = ({ state, libraries }) => {
-  const data = state.source.get("/blog/wp_template_part/footer/");
+  const data = state.source.get("/blog/footer/");
   const footer = state.source["wp_template_part"][data.id];
   const Html2React = libraries.html2react.Component;
 

--- a/packages/frontity-org-theme/src/components/headers/header-styles.ts
+++ b/packages/frontity-org-theme/src/components/headers/header-styles.ts
@@ -8,6 +8,7 @@ const tooltipStyles = ({ state }: { state: State<FrontityOrg> }) => css`
   left: unset;
   right: -12px;
   top: calc(100% + 16px);
+  background: white;
 
   padding: 2px 24px;
   border: none;
@@ -19,23 +20,7 @@ const tooltipStyles = ({ state }: { state: State<FrontityOrg> }) => css`
 
   transition: opacity 0.1s linear 0.5s, visibility 0.1s linear 0.5s;
 
-  /* Arrow */
-  :after {
-    content: " ";
-    width: 16px;
-    height: 16px;
-    position: absolute;
-    top: 0;
-    right: 9px;
-
-    transform: translate(-50%, -50%) rotate(45deg);
-
-    background-color: white;
-    border-left: 1px solid rgba(31, 56, 197, 0.09);
-    border-top: 1px solid rgba(31, 56, 197, 0.09);
-  }
-
-  .wp-block-navigation-link {
+  .wp-block-navigation-item {
     color: ${state.theme.colors.primary};
     padding: 16px 0;
     margin: 0;
@@ -45,13 +30,14 @@ const tooltipStyles = ({ state }: { state: State<FrontityOrg> }) => css`
     }
   }
 
-  .wp-block-navigation-link__content {
+  .wp-block-navigation-item__content {
     padding: 0;
     font-family: "IBMPlexSans";
   }
 
   /* icons margin */
-  .wp-block-navigation-link__label img {
+  .wp-block-navigation-item__label img {
+    display: inline;
     margin-right: 12px;
     width: 16px;
     height: 16px;
@@ -99,9 +85,9 @@ export const generalStyles = ({ state }: { state: State<FrontityOrg> }) => css`
   .wp-block-navigation {
     width: auto;
 
-    .wp-block-navigation-link {
+    .wp-block-navigation-item {
       min-height: fit-content;
-      .wp-block-navigation-link__content {
+      .wp-block-navigation-item__content {
         padding: 0;
         :hover {
           color: ${state.theme.colors.frontity};
@@ -127,7 +113,7 @@ export const desktopStyles = ({ state }: { state: State<FrontityOrg> }) =>
       /* Final padding at the right of the navbar */
       padding-right: 8px;
 
-      .wp-block-navigation-link {
+      .wp-block-navigation-item {
         align-items: center;
 
         /* Margins for links with only text */
@@ -135,22 +121,26 @@ export const desktopStyles = ({ state }: { state: State<FrontityOrg> }) =>
           margin-left: 40px;
         }
 
-        /* Margins for links with icons */
-        &.is-link-with-icon {
-          margin-left: 16px;
-        }
-        /* Tooltip styles */
-        &.has-child > .wp-block-navigation__container {
-          ${tooltipStyles({ state })};
-        }
-
-        .wp-block-navigation-link__content {
+        .wp-block-navigation-item__content {
           padding: 0;
         }
       }
 
+      /* Margins for links with icons */
+      .is-link-with-icon {
+        margin-left: 16px;
+      }
+      /* Tooltip styles */
+      .has-child {
+        display: block;
+        position: relative;
+        .wp-block-navigation__submenu-container {
+          ${tooltipStyles({ state })};
+        }
+      }
+
       /* Separator between links */
-      .wp-block-navigation-link:not(.is-link-with-icon) + .is-link-with-icon {
+      .wp-block-navigation-item:not(.is-link-with-icon) + .is-link-with-icon {
         margin-left: 0;
         &::before {
           content: " ";
@@ -163,9 +153,9 @@ export const desktopStyles = ({ state }: { state: State<FrontityOrg> }) =>
       }
 
       /* Style links with icons */
-      .wp-block-navigation-link.is-link-with-icon
-        > .wp-block-navigation-link__content
-        > .wp-block-navigation-link__label {
+      .wp-block-navigation-item.is-link-with-icon
+        > .wp-block-navigation-item__content
+        > .wp-block-navigation-item__label {
         font-size: 0;
         vertical-align: text-bottom;
 
@@ -244,7 +234,7 @@ export const mobileStyles = ({
         0 2px 4px 0 rgba(31, 56, 197, 0.12);
 
       /* Arrows at the end of the links */
-      > .wp-block-navigation-link > .wp-block-navigation-link__content:after {
+      > .wp-block-navigation-item > .wp-block-navigation-item__content:after {
         content: " ";
         width: 6px;
         height: 6px;
@@ -257,17 +247,17 @@ export const mobileStyles = ({
       }
     }
 
-    .wp-block-navigation-link {
+    .wp-block-navigation-item {
       flex-direction: column;
       color: ${state.theme.colors.frontity};
       border-top: 1px solid ${addAlpha(state.theme.colors.primary, 0.08)};
       font-size: 14px;
       line-height: 21px;
-      .wp-block-navigation-link__content {
+      .wp-block-navigation-item__content {
         padding: 24px 8px;
         width: auto;
       }
-      .wp-block-navigation-link__label {
+      .wp-block-navigation-item__label {
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -278,15 +268,18 @@ export const mobileStyles = ({
       }
     }
 
-    .wp-block-navigation-link.is-link-with-icon
-      > .wp-block-navigation-link__content
-      > .wp-block-navigation-link__label
+    .wp-block-navigation-item.is-link-with-icon
+      > .wp-block-navigation-item__content
       img {
       filter: saturate(2.3) hue-rotate(5deg);
     }
 
     /* Submenu */
-    .wp-block-navigation-link.has-child > .wp-block-navigation__container {
+    .wp-block-navigation-item.has-child {
+      margin: 0;
+    }
+    .wp-block-navigation-item.has-child
+      > .wp-block-navigation__submenu-container {
       max-width: none;
       position: static;
       visibility: visible;
@@ -294,7 +287,7 @@ export const mobileStyles = ({
       border: none;
       margin-left: 36px;
 
-      .wp-block-navigation-link {
+      .wp-block-navigation-item {
         font-family: "IBMPlexSans";
         font-size: 16px;
         letter-spacing: 0;
@@ -304,7 +297,7 @@ export const mobileStyles = ({
         }
       }
 
-      .wp-block-navigation-link__content {
+      .wp-block-navigation-item__content {
         padding: 12px 0;
       }
     }

--- a/packages/frontity-org-theme/src/components/headers/index.tsx
+++ b/packages/frontity-org-theme/src/components/headers/index.tsx
@@ -10,7 +10,7 @@ import { fixedHeaderStyles, headerStyles } from "./header-styles";
 export const Header = connect(() => {
   const { state, actions, libraries } = useConnect<Packages>();
   // Get the header template.
-  const data = state.source.get("/blog/wp_template_part/header-web/");
+  const data = state.source.get("/blog/header-web/");
 
   // Bail out if the data returned doesn't belong to a post type.
   if (!isPostType(data)) return null;
@@ -65,7 +65,7 @@ export const FixedHeader = connect(
   () => {
     const { state, libraries } = useConnect<Packages>();
     // Get the header template.
-    const data = state.source.get("/blog/wp_template_part/fixed-header/");
+    const data = state.source.get("/blog/fixed-header/");
 
     // Bail out if the data returned doesn't belong to a post type.
     if (!isPostType(data)) return null;

--- a/packages/frontity-org-theme/src/components/top-banner.tsx
+++ b/packages/frontity-org-theme/src/components/top-banner.tsx
@@ -6,7 +6,7 @@ import FrontityOrg from "../../types";
 
 const TopBanner: React.FC<Connect<FrontityOrg>> = ({ state, libraries }) => {
   // Get the banner template.
-  const data = state.source.get("/blog/wp_template_part/top-banner/");
+  const data = state.source.get("/blog/top-banner/");
   const banner = state.source["wp_template_part"][data.id];
 
   // Get the component that transform the template to React.


### PR DESCRIPTION
After updating to WordPress 5.9, some parts of the HTML changed and the web wasn't working.

The template parts URLs have changed and the navigation block HTML, so I changed that in order to match them.